### PR TITLE
Implement exception handling on windows/arm

### DIFF
--- a/src/runtime/asm_arm.s
+++ b/src/runtime/asm_arm.s
@@ -752,6 +752,9 @@ TEXT setg<>(SB),NOSPLIT|NOFRAME,$0-0
 	MOVW	R0, g
 
 	// Save g to thread-local storage.
+#ifdef GOOS_windows
+	B	runtime·save_g(SB)
+#else
 	MOVB	runtime·iscgo(SB), R0
 	CMP	$0, R0
 	B.EQ	2(PC)
@@ -759,6 +762,7 @@ TEXT setg<>(SB),NOSPLIT|NOFRAME,$0-0
 
 	MOVW	g, R0
 	RET
+#endif
 
 TEXT runtime·getcallerpc(SB),NOSPLIT|NOFRAME,$0-4
 	MOVW	0(R13), R0		// LR saved by caller

--- a/src/runtime/signal_windows.go
+++ b/src/runtime/signal_windows.go
@@ -27,7 +27,7 @@ func lastcontinuetramp()
 
 func initExceptionHandler() {
 	stdcall2(_AddVectoredExceptionHandler, 1, funcPC(exceptiontramp))
-	if _AddVectoredContinueHandler == nil || unsafe.Sizeof(&_AddVectoredContinueHandler) == 4 {
+	if  _AddVectoredContinueHandler == nil || GOARCH == "386" {
 		// use SetUnhandledExceptionFilter for windows-386 or
 		// if VectoredContinueHandler is unavailable.
 		// note: SetUnhandledExceptionFilter handler won't be called, if debugging.


### PR DESCRIPTION
Exception handling also requires the following Windows change to ntdll: 
https://microsoft.visualstudio.com/DefaultCollection/_git/os/commit/be183851112e8722a43f8428b50d9a3a272472d6?refName=refs%2Fheads%2Fuser%2Fjordanrh%2Fgolang-on-rs4-17134

This assumes you are running an RS4 RTM image (build 17134). 

To build and replace ntdll, in your OSG GIT enlistment, run

```
git checkout user/jordanrh/golang-on-rs4-17134
cd %sdxroot%\minkernel\ntdll\daytona
bcp
```

copy `%_nttree%\ntdll.dll` to your device, then run

    sfpcopy ntdll.dll c:\windows\system32\ntdll.dll