### PR TITLE
Windows arm64 port - Base relocation and exception handling

### DIFF
--- a/src/runtime/defs_windows_arm64.go
+++ b/src/runtime/defs_windows_arm64.go
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// TODO(ragav): adapt to arm64
 package runtime
 
 const (
@@ -46,7 +45,7 @@ type systeminfo struct {
 	dwpagesize                  uint32
 	lpminimumapplicationaddress *byte
 	lpmaximumapplicationaddress *byte
-	dwactiveprocessormask       uint32
+	dwactiveprocessormask       uint64
 	dwnumberofprocessors        uint32
 	dwprocessortype             uint32
 	dwallocationgranularity     uint32
@@ -68,46 +67,62 @@ type neon128 struct {
 	high int64
 }
 
+// See: https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-arm64_nt_context
 type context struct {
 	contextflags uint32
-	r0           uint32
-	r1           uint32
-	r2           uint32
-	r3           uint32
-	r4           uint32
-	r5           uint32
-	r6           uint32
-	r7           uint32
-	r8           uint32
-	r9           uint32
-	r10          uint32
-	r11          uint32
-	r12          uint32
+	cpsr         uint32
+	r0           uint64
+	r1           uint64
+	r2           uint64
+	r3           uint64
+	r4           uint64
+	r5           uint64
+	r6           uint64
+	r7           uint64
+	r8           uint64
+	r9           uint64
+	r10          uint64
+	r11          uint64
+	r12          uint64
+	r13          uint64
+	r14          uint64
+	r15          uint64
+	r16          uint64
+	r17          uint64
+	r18          uint64
+	r19          uint64
+	r20          uint64
+	r21          uint64
+	r22          uint64
+	r23          uint64
+	r24          uint64
+	r25          uint64
+	r26          uint64
+	r27          uint64
+	r28          uint64
 
-	spr  uint32
-	lrr  uint32
-	pc   uint32
-	cpsr uint32
+	fp  uint64
+	lrr uint64
+	spr uint64
+	pc  uint64
 
-	fpscr   uint32
-	padding uint32
+	floatNeon [32]neon128
+	fpsr      uint32
+	fpcr      uint32
 
-	floatNeon [16]neon128
-
-	bvr      [8]uint32
-	bcr      [8]uint32
-	wvr      [1]uint32
-	wcr      [1]uint32
-	padding2 [2]uint32
+	bcr [8]uint32
+	bvr [8]uint64
+	wcr [2]uint32
+	wvr [2]uint64
 }
 
 func (c *context) ip() uintptr { return uintptr(c.pc) }
 func (c *context) sp() uintptr { return uintptr(c.spr) }
 func (c *context) lr() uintptr { return uintptr(c.lrr) }
 
-func (c *context) set_ip(x uintptr) { c.pc = uint32(x) }
-func (c *context) set_sp(x uintptr) { c.spr = uint32(x) }
-func (c *context) set_lr(x uintptr) { c.lrr = uint32(x) }
+func (c *context) set_ip(x uintptr) { c.pc = uint64(x) }
+func (c *context) set_sp(x uintptr) { c.spr = uint64(x) }
+func (c *context) set_lr(x uintptr) { c.lrr = uint64(x) }
 
 func dumpregs(r *context) {
 	print("r0   ", hex(r.r0), "\n")
@@ -123,6 +138,23 @@ func dumpregs(r *context) {
 	print("r10  ", hex(r.r10), "\n")
 	print("r11  ", hex(r.r11), "\n")
 	print("r12  ", hex(r.r12), "\n")
+	print("r13  ", hex(r.r13), "\n")
+	print("r14  ", hex(r.r14), "\n")
+	print("r15  ", hex(r.r15), "\n")
+	print("r16  ", hex(r.r16), "\n")
+	print("r17  ", hex(r.r17), "\n")
+	print("r18  ", hex(r.r18), "\n")
+	print("r19  ", hex(r.r19), "\n")
+	print("r20  ", hex(r.r20), "\n")
+	print("r21  ", hex(r.r21), "\n")
+	print("r22  ", hex(r.r22), "\n")
+	print("r23  ", hex(r.r23), "\n")
+	print("r24  ", hex(r.r24), "\n")
+	print("r25  ", hex(r.r25), "\n")
+	print("r26  ", hex(r.r26), "\n")
+	print("r27  ", hex(r.r27), "\n")
+	print("r28  ", hex(r.r28), "\n")
+	print("fp   ", hex(r.fp), "\n")
 	print("sp   ", hex(r.spr), "\n")
 	print("lr   ", hex(r.lrr), "\n")
 	print("pc   ", hex(r.pc), "\n")
@@ -130,8 +162,8 @@ func dumpregs(r *context) {
 }
 
 type overlapped struct {
-	internal     uint32
-	internalhigh uint32
+	internal     uint64
+	internalhigh uint64
 	anon0        [8]byte
 	hevent       *byte
 }
@@ -147,5 +179,5 @@ type memoryBasicInformation struct {
 }
 
 func stackcheck() {
-	// TODO(ragav): not implemented on ARM64
+	// TODO: not implemented on ARM64
 }

--- a/src/runtime/syscall_windows.go
+++ b/src/runtime/syscall_windows.go
@@ -35,12 +35,9 @@ func callbackasm()
 // and we want callback to arrive at
 // correspondent call instruction instead of start of
 // runtime.callbackasm.
-// On ARM, runtime.callbackasm is a series of mov and branch instructions.
+// On ARM and ARM64, runtime.callbackasm is a series of mov and branch instructions.
 // R12 is loaded with the callback index. Each entry is two instructions,
 // hence 8 bytes.
-// On ARM64, runtime.callbackasm is a series of mov and branch instructions.
-// R16 is loaded with the callback index. Each entry is two instructions,
-// hence 16 bytes. TODO(ragav): need to verify this.
 func callbackasmAddr(i int) uintptr {
 	var entrySize int
 	switch GOARCH {
@@ -48,13 +45,10 @@ func callbackasmAddr(i int) uintptr {
 		panic("unsupported architecture")
 	case "386", "amd64":
 		entrySize = 5
-	case "arm":
+	case "arm", "arm64":
 		// On ARM, each entry is a MOV instruction
 		// followed by a branch instruction
 		entrySize = 8
-	//TODO(ragav): check for the correctness of arm64 case
-	case "arm64":
-		entrySize = 16
 	}
 	return funcPC(callbackasm) + uintptr(i*entrySize)
 }

--- a/src/runtime/tls_arm64.s
+++ b/src/runtime/tls_arm64.s
@@ -10,58 +10,58 @@
 
 TEXT runtime·load_g(SB),NOSPLIT,$0
 #ifdef GOOS_windows
-	WORD	$0xaa1203e0					// MOVD	R18, R0 i.e. R0 has the base of TEB
-	ADD		$0xe10, R0					// Offset for TLS slots
-	MOVD 	$runtime·tls_g(SB), g		// pointer to tls_g
-	MOVD	(g), g						// index value of tls_g (in the TSL slots array)
-	LSL     $2, g, g      				// g = g<<2 offset for tls_g
-	MOVD	(g)(R0), g					// load g
-	RET
+    WORD    $0xaa1203e0                 // MOVD R18, R0 i.e. R0 has the base of TEB
+    ADD     $0xe10, R0                  // Offset for TLS slots
+    MOVD    $runtime·tls_g(SB), g       // pointer to tls_g
+    MOVD    (g), g                      // index value of tls_g (in the TSL slots array)
+    LSL     $2, g, g                    // g = g<<2 offset for tls_g
+    MOVD    (g)(R0), g                  // load g
+    RET
 #else
-	
-	MOVB	runtime·iscgo(SB), R0
-	CMP	$0, R0
-	BEQ	nocgo
+    
+    MOVB    runtime·iscgo(SB), R0
+    CMP $0, R0
+    BEQ nocgo
 
-	MRS_TPIDR_R0
+    MRS_TPIDR_R0
 #ifdef GOOS_darwin
-	// Darwin sometimes returns unaligned pointers
-	AND	$0xfffffffffffffff8, R0
+    // Darwin sometimes returns unaligned pointers
+    AND $0xfffffffffffffff8, R0
 #endif
-	MOVD	runtime·tls_g(SB), R27
-	ADD	R27, R0
-	MOVD	0(R0), g
+    MOVD    runtime·tls_g(SB), R27
+    ADD R27, R0
+    MOVD    0(R0), g
 
 nocgo:
-	RET
+    RET
 #endif
 
 TEXT runtime·save_g(SB),NOSPLIT,$0
 #ifdef GOOS_windows
-	WORD	$0xaa1203e0					// MOVD	R18, R0 i.e. R0 has the base of TEB
-	ADD		$0xe10, R0					// Offset for TLS slots
-	MOVD 	$runtime·tls_g(SB), R29		// pointer to tls_g
-	MOVD	(R29), R29					// index value of tls_g (in the TSL slots array)
-	LSL 	$2, R29, R8					// offset for tls_g
-	MOVD	g, (R8)(R0)					// save g to tls
-	MOVD	g, R0						// preserve R0 across call to setg<>
-	RET
-#else	
-	MOVB	runtime·iscgo(SB), R0
-	CMP	$0, R0
-	BEQ	nocgo
+    WORD    $0xaa1203e0                 // MOVD R18, R0 i.e. R0 has the base of TEB
+    ADD     $0xe10, R0                  // Offset for TLS slots
+    MOVD    $runtime·tls_g(SB), R29     // pointer to tls_g
+    MOVD    (R29), R29                  // index value of tls_g (in the TSL slots array)
+    LSL     $2, R29, R8                 // offset for tls_g
+    MOVD    g, (R8)(R0)                 // save g to tls
+    MOVD    g, R0                       // preserve R0 across call to setg<>
+    RET
+#else   
+    MOVB    runtime·iscgo(SB), R0
+    CMP $0, R0
+    BEQ nocgo
 
-	MRS_TPIDR_R0
+    MRS_TPIDR_R0
 #ifdef GOOS_darwin
-	// Darwin sometimes returns unaligned pointers
-	AND	$0xfffffffffffffff8, R0
+    // Darwin sometimes returns unaligned pointers
+    AND $0xfffffffffffffff8, R0
 #endif
-	MOVD	runtime·tls_g(SB), R27
-	ADD	R27, R0
-	MOVD	g, 0(R0)
-	
+    MOVD    runtime·tls_g(SB), R27
+    ADD R27, R0
+    MOVD    g, 0(R0)
+    
 nocgo:
-	RET
+    RET
 #endif
 
 #ifdef TLSG_IS_VARIABLE

--- a/src/runtime/wincallback.go
+++ b/src/runtime/wincallback.go
@@ -73,7 +73,6 @@ TEXT runtime·callbackasm(SB),NOSPLIT|NOFRAME,$0
 	}
 }
 
-//TODO(ragav): check for correctness
 func genasmArm64() {
 	var buf bytes.Buffer
 

--- a/src/syscall/syscall_windows.go
+++ b/src/syscall/syscall_windows.go
@@ -344,14 +344,13 @@ func setFilePointerEx(handle Handle, distToMove int64, newFilePointer *int64, wh
 	switch runtime.GOARCH {
 	default:
 		panic("unsupported architecture")
-	case "amd64":
+	case "amd64", "arm64":
 		_, _, e1 = Syscall6(procSetFilePointerEx.Addr(), 4, uintptr(handle), uintptr(distToMove), uintptr(unsafe.Pointer(newFilePointer)), uintptr(whence), 0, 0)
 	case "386":
 		// distToMove is a LARGE_INTEGER:
 		// https://msdn.microsoft.com/en-us/library/windows/desktop/aa383713(v=vs.85).aspx
 		_, _, e1 = Syscall6(procSetFilePointerEx.Addr(), 5, uintptr(handle), uintptr(distToMove), uintptr(distToMove>>32), uintptr(unsafe.Pointer(newFilePointer)), uintptr(whence), 0)
-	// TODO(ragav): Verify arm64 case.
-	case "arm", "arm64":
+	case "arm":
 		// distToMove must be 8-byte aligned per ARM calling convention
 		// https://msdn.microsoft.com/en-us/library/dn736986.aspx#Anchor_7
 		_, _, e1 = Syscall6(procSetFilePointerEx.Addr(), 6, uintptr(handle), 0, uintptr(distToMove), uintptr(distToMove>>32), uintptr(unsafe.Pointer(newFilePointer)), uintptr(whence))


### PR DESCRIPTION
**Description:**
- Added relocation support for arm64 executables. 
- Implemented exception handling functionality.

**Result:**
- Able to pass all 154 tests in the test suite (using -test.short flag) that the arm32 port passes and more.

**Known shortcomings:**
- Does not pass all test cases in the test suite.
- Unimplemented functions: runtime·externalthreadhandler, runtime·badsignal2, runtime·callbackasm1