### PR TITLE
Windows arm64 port: Fixed tls offset and some types.

### DIFF
--- a/src/cmd/vendor/golang.org/x/sys/windows/types_windows_arm64.go
+++ b/src/cmd/vendor/golang.org/x/sys/windows/types_windows_arm64.go
@@ -7,16 +7,16 @@ package windows
 type WSAData struct {
 	Version      uint16
 	HighVersion  uint16
-	Description  [WSADESCRIPTION_LEN + 1]byte
-	SystemStatus [WSASYS_STATUS_LEN + 1]byte
 	MaxSockets   uint16
 	MaxUdpDg     uint16
 	VendorInfo   *byte
+	Description  [WSADESCRIPTION_LEN + 1]byte
+	SystemStatus [WSASYS_STATUS_LEN + 1]byte
 }
 
 type Servent struct {
 	Name    *byte
 	Aliases **byte
-	Port    uint16
 	Proto   *byte
+	Port    uint16
 }

--- a/src/runtime/sys_windows_arm64.s
+++ b/src/runtime/sys_windows_arm64.s
@@ -647,7 +647,7 @@ TEXT runtime·alloc_tls(SB),NOSPLIT|NOFRAME,$0
 TEXT runtime·init_thread_tls(SB),NOSPLIT|NOFRAME,$0
     // compute &_TEB->TlsSlots[tls_g]
     WORD    $0xaa1203e0     // MOVD R18, R0
-    ADD     $0xe10, R0
+    ADD     $0x1480, R0
     MOVD    $runtime·tls_g(SB), R1
     MOVD    (R1), R1
     LSL     $2, R1, R1

--- a/src/runtime/tls_arm64.s
+++ b/src/runtime/tls_arm64.s
@@ -39,7 +39,7 @@ nocgo:
 TEXT runtime·save_g(SB),NOSPLIT,$0
 #ifdef GOOS_windows
     WORD    $0xaa1203e0                 // MOVD R18, R0 i.e. R0 has the base of TEB
-    ADD     $0x1480, R0                  // Offset for TLS slots
+    ADD     $0x1480, R0                 // Offset for TLS slots
     MOVD    $runtime·tls_g(SB), R29     // pointer to tls_g
     MOVD    (R29), R29                  // index value of tls_g (in the TSL slots array)
     LSL     $2, R29, R8                 // offset for tls_g

--- a/src/runtime/tls_arm64.s
+++ b/src/runtime/tls_arm64.s
@@ -11,7 +11,7 @@
 TEXT runtime·load_g(SB),NOSPLIT,$0
 #ifdef GOOS_windows
     WORD    $0xaa1203e0                 // MOVD R18, R0 i.e. R0 has the base of TEB
-    ADD     $0x1480, R0                  // Offset for TLS slots
+    ADD     $0x1480, R0                 // Offset for TLS slots
     MOVD    $runtime·tls_g(SB), g       // pointer to tls_g
     MOVD    (g), g                      // index value of tls_g (in the TSL slots array)
     LSL     $2, g, g                    // g = g<<2 offset for tls_g

--- a/src/runtime/tls_arm64.s
+++ b/src/runtime/tls_arm64.s
@@ -11,7 +11,7 @@
 TEXT runtime·load_g(SB),NOSPLIT,$0
 #ifdef GOOS_windows
     WORD    $0xaa1203e0                 // MOVD R18, R0 i.e. R0 has the base of TEB
-    ADD     $0xe10, R0                  // Offset for TLS slots
+    ADD     $0x1480, R0                  // Offset for TLS slots
     MOVD    $runtime·tls_g(SB), g       // pointer to tls_g
     MOVD    (g), g                      // index value of tls_g (in the TSL slots array)
     LSL     $2, g, g                    // g = g<<2 offset for tls_g
@@ -39,7 +39,7 @@ nocgo:
 TEXT runtime·save_g(SB),NOSPLIT,$0
 #ifdef GOOS_windows
     WORD    $0xaa1203e0                 // MOVD R18, R0 i.e. R0 has the base of TEB
-    ADD     $0xe10, R0                  // Offset for TLS slots
+    ADD     $0x1480, R0                  // Offset for TLS slots
     MOVD    $runtime·tls_g(SB), R29     // pointer to tls_g
     MOVD    (R29), R29                  // index value of tls_g (in the TSL slots array)
     LSL     $2, R29, R8                 // offset for tls_g

--- a/src/syscall/types_windows_arm64.go
+++ b/src/syscall/types_windows_arm64.go
@@ -7,16 +7,16 @@ package syscall
 type WSAData struct {
 	Version      uint16
 	HighVersion  uint16
-	Description  [WSADESCRIPTION_LEN + 1]byte
-	SystemStatus [WSASYS_STATUS_LEN + 1]byte
 	MaxSockets   uint16
 	MaxUdpDg     uint16
 	VendorInfo   *byte
+	Description  [WSADESCRIPTION_LEN + 1]byte
+	SystemStatus [WSASYS_STATUS_LEN + 1]byte
 }
 
 type Servent struct {
 	Name    *byte
 	Aliases **byte
-	Port    uint16
 	Proto   *byte
+	Port    uint16
 }


### PR DESCRIPTION
The tls offset was incorrect. [See this](https://github.com/DynamoRIO/dynamorio/blob/master/core/win32/ntdll.h#L612).

Similarly, WSAData and Servent structs are different for 64-bit archs and should be like the ones in amd64 file.
